### PR TITLE
Add ui delegate to open external urls in safari

### DIFF
--- a/webviews/wkwebview/wkwebview/LinkViewController.swift
+++ b/webviews/wkwebview/wkwebview/LinkViewController.swift
@@ -8,7 +8,7 @@
 import UIKit
 import WebKit
 
-final class LinkViewController: UIViewController, WKNavigationDelegate {
+final class LinkViewController: UIViewController, WKNavigationDelegate, WKUIDelegate {
 
     /// `handleRedirctURL` checks the `url` to see if it matches the redirect url used when creating a link token.
     /// If so, it re-initializes the webview to finish the link session. Returns `true` if handled, `false` otherwise.
@@ -38,6 +38,7 @@ final class LinkViewController: UIViewController, WKNavigationDelegate {
         super.viewDidLoad()
 
         webView.navigationDelegate = self
+        webView.uiDelegate = self
         webView.allowsBackForwardNavigationGestures = false
         webView.frame = view.frame
         webView.scrollView.bounces = false
@@ -50,6 +51,23 @@ final class LinkViewController: UIViewController, WKNavigationDelegate {
 
     override var prefersStatusBarHidden : Bool {
         return true
+    }
+
+    // MARK: WKUIDelegate
+
+    func webView(
+        _ webView: WKWebView,
+        createWebViewWith configuration: WKWebViewConfiguration,
+        for navigationAction: WKNavigationAction,
+        windowFeatures: WKWindowFeatures
+    ) -> WKWebView? {
+        guard let url = navigationAction.request.url else {
+            return
+        }
+
+        // Open the external URL in Safari
+        UIApplication.shared.open(url)
+        return nil
     }
 
     // MARK: WKNavigationDelegate

--- a/webviews/wkwebview/wkwebview/LinkViewController.swift
+++ b/webviews/wkwebview/wkwebview/LinkViewController.swift
@@ -62,7 +62,7 @@ final class LinkViewController: UIViewController, WKNavigationDelegate, WKUIDele
         windowFeatures: WKWindowFeatures
     ) -> WKWebView? {
         guard let url = navigationAction.request.url else {
-            return
+            return nil
         }
 
         // Open the external URL in Safari


### PR DESCRIPTION
### Context
- some oauth flows may open the login portal as a new tab in safari instead of redirecting the webview
- currently, this example ios webview integration does not support this 

### Description
- adds a WKUIDelegate to support opening the oauth login portal in safari
- 
![gif](https://user-images.githubusercontent.com/9733570/184950453-80c2d41d-960a-49b6-b8d8-b0e05ccb144b.gif)