### PR TITLE
Remove webcontentsDebuggable setting in Android Examples

### DIFF
--- a/webviews/android/LinkWebview/app/src/main/java/com/example/linkwebview/MainActivity.kt
+++ b/webviews/android/LinkWebview/app/src/main/java/com/example/linkwebview/MainActivity.kt
@@ -105,9 +105,6 @@ class MainActivity : ComponentActivity() {
             cacheMode = WebSettings.LOAD_NO_CACHE
         }
 
-        // Optional: This allows all traffic to be debugged, should be turned off in production.
-        WebView.setWebContentsDebuggingEnabled(true)
-
         // Override the Webview's handler for redirects
         // Link communicates success and failure (analogous to the web's onSuccess and onExit
         // callbacks) via redirects.

--- a/webviews/androidpublickey/app/src/main/java/plaid/samplewebviewapp/MainActivity.java
+++ b/webviews/androidpublickey/app/src/main/java/plaid/samplewebviewapp/MainActivity.java
@@ -46,7 +46,6 @@ public class MainActivity extends AppCompatActivity {
         webSettings.setJavaScriptEnabled(true);
         webSettings.setDomStorageEnabled(true);
         webSettings.setCacheMode(WebSettings.LOAD_NO_CACHE);
-        WebView.setWebContentsDebuggingEnabled(true);
 
         // Initialize Link by loading the Link initialization URL in the Webview
         plaidLinkWebview.loadUrl(linkInitializationUrl.toString());


### PR DESCRIPTION
Having the `WebView.setWebContentsDebuggingEnabled` flag set to true is a security concern in production builds. It is being removed from these examples so that it is not accidentally copied from the example and set in production.